### PR TITLE
Fix crash in parseEntities and hlbsp_loadTextures

### DIFF
--- a/src/hlbsp.cpp
+++ b/src/hlbsp.cpp
@@ -414,7 +414,7 @@ bool Map::load_hlbsp(FILE *f, const char *name, LoadConfig *config)
 	return true;
 }
 
-void Map::hlbsp_loadTextures(FILE *f, int fileofs, int filelen, std::vector<WadFile> wads, bool verbose)
+void Map::hlbsp_loadTextures(FILE *f, int fileofs, int filelen, std::vector<WadFile> &wads, bool verbose)
 {
 	using namespace hlbsp;
 	if (!filelen)
@@ -532,16 +532,15 @@ void Map::parseEntities(const char *src, size_t size)
 					if (e == std::string::npos)
 						e = token.size();
 
-					if (e - s > 0)
-					{
-						std::string temp = token.substr(s, e - s);
-						size_t p = temp.find_last_of("/\\");
-						if (p != std::string::npos)
-							temp = temp.substr(p + 1);
-						wadNames.push_back(temp);
-					}
-					else
+					if (s >= e)
 						break;
+
+					std::string temp = token.substr(s, e - s);
+					size_t p = temp.find_last_of("/\\");
+					if (p != std::string::npos)
+						temp = temp.substr(p + 1);
+					wadNames.push_back(temp);
+
 					s = e + 1;
 				}
 			}

--- a/src/map.h
+++ b/src/map.h
@@ -80,7 +80,7 @@ private:
 	bool load_hlbsp(FILE *f, const char *name, LoadConfig *config = nullptr);
 	bool load_vbsp(FILE *f, const char *name, LoadConfig *config = nullptr);
 
-	void hlbsp_loadTextures(FILE *f, int fileofs, int filelen, std::vector<WadFile> wads, bool verbose);
+	void hlbsp_loadTextures(FILE *f, int fileofs, int filelen, std::vector<WadFile> &wads, bool verbose);
 	void parseEntities(const char *src, size_t size);
 
 	std::vector<std::string> wadNames;

--- a/src/wad.cpp
+++ b/src/wad.cpp
@@ -13,7 +13,10 @@
 WadFile::~WadFile()
 {
 	if(f)
+	{
 		fclose(f);
+		f = 0;
+	}
 }
 
 bool WadFile::load(const char *path)


### PR DESCRIPTION
in parseEntities check if s is greater/equal to e. Since they are unsigned int e - s underflows producing a large number.

in hlbsp_loadTextures pass wads as reference. Not only is it faster (no copies) it also fixes a bug of double free. Copied wads would also call their destructor trying to fclose the same file handle.